### PR TITLE
Update for Django version 1.11

### DIFF
--- a/fetchstatic/management/commands/fetch_static.py
+++ b/fetchstatic/management/commands/fetch_static.py
@@ -13,20 +13,16 @@ log = logging.getLogger(__name__)
 class Command(BaseCommand):
     help = "Download libraries from internet to static folder"
 
-    option_list = BaseCommand.option_list + (
-            make_option("-f", "--force",
-                action="store_true",
-                dest="force",
-                default=False,
-                help="Overwrite existing files while downloading"),
+    def add_arguments(self, parser):
+        parser.add_argument("-f", "--force", action="store_true",
+            dest="force", default=False,
+            help="Overwrite existing files while downloading",
         )
+        parser.add_argument("directory", help="Target directory path")
 
     def handle(self, *args, **options):
         self.force = options["force"]
-
-        if not args:
-            raise ValueError("Please specify path for fetching")
-        _static_dir = args[0]
+        _static_dir = options["directory"]
         _temp_dir = os.path.join(_static_dir, "__temp")
 
         _fetcher = StaticFetcher(settings.STATIC_LIBS, _static_dir, _temp_dir)


### PR DESCRIPTION
v1.11 uses _argparse_ instead of _optparse,_ and it requires all arguments to be defined in the parser.

There is no `option_list` in v1.11.  The `create_parser()` method has the same signature, but `handle()` still has to be adjusted for incompatible handling of positional arguments.